### PR TITLE
Allow to set additional core folders that should be linked to web directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ all installed (system) extensions.
 Note that `uploads` will not be exposed by default. Depending on your setup,
 you might consider linking some or all folders to the `web` as well.
 
+To do so you can add the following configuration to your root composer.json file:
+
+```json
+    "extra": {
+        "typo3/cms": {
+            "public-core-folders": [
+                "uploads"
+            ]
+        }
+    }
+```

--- a/src/Composer/InstallerScript/WebDirectory.php
+++ b/src/Composer/InstallerScript/WebDirectory.php
@@ -107,6 +107,7 @@ class WebDirectory implements InstallerScript
             'fileadmin',
             'typo3temp/assets'
         ];
+        $coreLinks = array_merge($coreLinks, (array) $this->pluginConfig->get('public-core-folders'));
 
         $webDir = $this->filesystem->normalizePath($this->pluginConfig->get('web-dir'));
         $rootDir = $this->filesystem->normalizePath($this->pluginConfig->get('root-dir'));


### PR DESCRIPTION
The folders can be specified in root composer.json as array in
extra/"typo3/cms"/public-core-folders