### PR TITLE
Update requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
     ],
     "require": {
         "typo3/cms-composer-installers": "^3.0",
-        "typo3/cms-core": ">=9.5.20"
+        "typo3/cms-core": ">=9.5.20",
+        "typo3/cms-frontend": ">=9.5.20",
+        "typo3/cms-backend": ">=9.5.20",
+        "typo3/cms-install": ">=9.5.20"
     },
     "require-dev": {
         "typo3/cms-filelist": "@dev",


### PR DESCRIPTION
As the Typo3EntryPointFinder->find() method expects following to be
installed, they have been added to composer.json to ensure this.

Added dependencies:
 typo3/cms-frontend
 typo3/cms-backend
 typo3/cms-install as requirements

Resolves: #24