### PR TITLE
[MOD] sym-link `typo3temp` directly

### DIFF
--- a/src/Composer/InstallerScript/WebDirectory.php
+++ b/src/Composer/InstallerScript/WebDirectory.php
@@ -86,7 +86,7 @@ class WebDirectory implements InstallerScript
 
         $coreLinks = [
             'fileadmin',
-            'typo3temp/assets',
+            'typo3temp',
         ];
 
         $webDir = $this->filesystem->normalizePath($this->pluginConfig->get('web-dir'));


### PR DESCRIPTION
`lochmueller/staticfilecache` cache-folder has to be linked manualy [[ref.]](https://github.com/lochmueller/staticfilecache/issues/379)
or do you see/know any problem (maybee with typo3 v9) linking "all"?

https://github.com/lochmueller/staticfilecache/blob/6dd7cf059ddbfbd60f286dbc0f5c7529618f879d/Classes/Service/CacheService.php#L40-L43
https://github.com/lochmueller/staticfilecache/blob/3d90163ba1c08e988b0cf78dfd471a80e3efa038/ext_conf_template.txt#L43-L44